### PR TITLE
OpenShift compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2023-02-20
+
+### Changed
+
+- Extend base image reference with registry url.
+- Make images OpenShift compatible by applying the [arbitrary user id](https://docs.openshift.com/container-platform/4.12/openshift_images/create-images.html#images-create-guide-openshift_create-images) logic.
+
 ## 2022-09-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,10 +7,28 @@ Get an Axon Ivy Engine running with only one command:
 
     docker run -p 8080:8080 axonivy/axonivy-engine
 
-Open your browser and go to http://localhost:8080
+Open your browser and go to <http://localhost:8080>
 
 We have many [docker-samples](https://github.com/ivy-samples/docker-samples)
 to see how Axon Ivy Engine can be used in a docker container.
+
+## Development
+
+Build your Image locally:
+
+```s
+VERSION=10.0
+ENGINE_URL=https://developer.axonivy.com/permalink/${VERSION}/axonivy-engine.zip
+IMAGE=axonivy/axonivy-engine
+IMAGE_TAG=${IMAGE}:${VERSION}-local
+docker build -t ${IMAGE_TAG} axonivy-engine/${VERSION} --build-arg IVY_ENGINE_DOWNLOAD_URL=${ENGINE_URL}
+```
+
+Run your fresh built Image with this command:
+
+```s
+docker run -p 8080:8080 ${IMAGE_TAG}
+```
 
 ## Changelog
 

--- a/axonivy-engine/10.0/Dockerfile
+++ b/axonivy-engine/10.0/Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get update && \
     ln -s ${IVY_HOME}/logs /var/log/axonivy-engine
 
 ADD --chown=ivy:ivy ./docker-entrypoint.sh ${IVY_HOME}/bin/docker-entrypoint.sh
-RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh 
+RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh && \
+\
+    chgrp -R 0 ${IVY_HOME} && \
+    chmod -R g=u ${IVY_HOME}
 
 WORKDIR ${IVY_HOME}
 USER 1000

--- a/axonivy-engine/10.0/Dockerfile
+++ b/axonivy-engine/10.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-jammy
+FROM docker.io/eclipse-temurin:17-jre-jammy
 LABEL maintainer="Axon Ivy AG <info@axonivy.com>" 
 
 ARG IVY_ENGINE_DOWNLOAD_URL

--- a/axonivy-engine/11/Dockerfile
+++ b/axonivy-engine/11/Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get update && \
     ln -s ${IVY_HOME}/logs /var/log/axonivy-engine
 
 ADD --chown=ivy:ivy ./docker-entrypoint.sh ${IVY_HOME}/bin/docker-entrypoint.sh
-RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh 
+RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh && \
+\
+    chgrp -R 0 ${IVY_HOME} && \
+    chmod -R g=u ${IVY_HOME}
 
 WORKDIR ${IVY_HOME}
 USER 1000

--- a/axonivy-engine/11/Dockerfile
+++ b/axonivy-engine/11/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-jammy
+FROM docker.io/eclipse-temurin:17-jre-jammy
 LABEL maintainer="Axon Ivy AG <info@axonivy.com>" 
 
 ARG IVY_ENGINE_DOWNLOAD_URL

--- a/axonivy-engine/8.0/Dockerfile
+++ b/axonivy-engine/8.0/Dockerfile
@@ -36,7 +36,10 @@ RUN apt-get update && \
     ln -s ${IVY_HOME}/logs /var/log/axonivy-engine-8
 
 ADD --chown=ivy:ivy ./docker-entrypoint.sh ${IVY_HOME}/bin/docker-entrypoint.sh
-RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh 
+RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh && \
+\
+    chgrp -R 0 ${IVY_HOME} && \
+    chmod -R g=u ${IVY_HOME}
 
 WORKDIR ${IVY_HOME}
 USER 1000

--- a/axonivy-engine/8.0/Dockerfile
+++ b/axonivy-engine/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM docker.io/eclipse-temurin:11-jre-focal
 LABEL maintainer="Axon Ivy AG <info@axonivy.com>" 
 
 ARG IVY_ENGINE_DOWNLOAD_URL

--- a/axonivy-engine/9.4/Dockerfile
+++ b/axonivy-engine/9.4/Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get update && \
     ln -s ${IVY_HOME}/logs /var/log/axonivy-engine
 
 ADD --chown=ivy:ivy ./docker-entrypoint.sh ${IVY_HOME}/bin/docker-entrypoint.sh
-RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh 
+RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh && \
+\
+    chgrp -R 0 ${IVY_HOME} && \
+    chmod -R g=u ${IVY_HOME}
 
 WORKDIR ${IVY_HOME}
 USER 1000

--- a/axonivy-engine/9.4/Dockerfile
+++ b/axonivy-engine/9.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-focal
+FROM docker.io/eclipse-temurin:17-jre-focal
 LABEL maintainer="Axon Ivy AG <info@axonivy.com>" 
 
 ARG IVY_ENGINE_DOWNLOAD_URL

--- a/axonivy-engine/9/Dockerfile
+++ b/axonivy-engine/9/Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get update && \
     ln -s ${IVY_HOME}/logs /var/log/axonivy-engine
 
 ADD --chown=ivy:ivy ./docker-entrypoint.sh ${IVY_HOME}/bin/docker-entrypoint.sh
-RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh 
+RUN chmod u+x ${IVY_HOME}/bin/docker-entrypoint.sh && \
+\
+    chgrp -R 0 ${IVY_HOME} && \
+    chmod -R g=u ${IVY_HOME}
 
 WORKDIR ${IVY_HOME}
 USER 1000

--- a/axonivy-engine/9/Dockerfile
+++ b/axonivy-engine/9/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM docker.io/eclipse-temurin:11-jre-focal
 LABEL maintainer="Axon Ivy AG <info@axonivy.com>" 
 
 ARG IVY_ENGINE_DOWNLOAD_URL


### PR DESCRIPTION
Make images OpenShift compatible by applying the [arbitrary user id](https://docs.openshift.com/container-platform/4.12/openshift_images/create-images.html#images-create-guide-openshift_create-images) logic.

Tested all images.

Problem with version 9 also without my changes:
`JVM must have version 17 or greater (/opt/java/openjdk/bin/java), but has version 11.`

Version 11 not available: 
```
https://developer.axonivy.com/permalink/11/axonivy-engine.zip:
2023-02-21 07:46:28 ERROR 404: Not Found.
```