### PR TITLE
XIVY-9197 Provide Axon Ivy Engine image also for linux/arm64 os architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2023-06-07
+
+### Added
+
+- Provide Axon Ivy Engine images for linux/arm64 os architecture (8.0.34 and higher, 10.0.9 and higher, 11.1.1 and higher, 11.2.0 and higher)
+
 ## 2023-06-06
 
 ### Changed


### PR DESCRIPTION
I've already published the dev image for two architectures:
https://hub.docker.com/r/axonivy/axonivy-engine/tags
https://hub.docker.com/layers/axonivy/axonivy-engine/dev/images/sha256-cd1028d88c55f1d5ee88fa2db968b24c9a13b3eb44c3ac150f1bc78c09f67620?context=explore

Seems fine to me..