### PR TITLE
arm64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,13 +88,13 @@ fi
 
 FULL_VERSION_TAG=""
 if [ $(isOfficialRelease $VERSION) == "yes" ]; then
-    FULL_VERSION_TAG=--tag ${IMAGE}:${FULL_VERSION}
+    FULL_VERSION_TAG="--tag ${IMAGE}:${FULL_VERSION}"
     echo "tag official release with ${FULL_VERSION_TAG}"
 fi
 
-LATEST_VERSION_TAG
+LATEST_VERSION_TAG=""
 if [ $(isCurrentLTS $VERSION) == "yes" ]; then
-    LATEST_VERSION_TAG=--tag ${IMAGE}:latest
+    LATEST_VERSION_TAG="--tag ${IMAGE}:latest"
     echo "tag official LTS release with ${LATEST_VERSION_TAG}"
 fi
 


### PR DESCRIPTION
- XIVY-9197 Provide Axon Ivy Engine image also for linux/arm64 os architectures
- Fix build.sh
- XIVY-9197 Tag image in one go
- Fix build.sh
