### PR TITLE
Set provenance=true docker buildx option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,4 +98,4 @@ if [ $(isCurrentLTS $VERSION) == "yes" ]; then
     echo "tag official LTS release with ${LATEST_VERSION_TAG}"
 fi
 
-docker buildx build --no-cache --pull --tag ${IMAGE_TAG} ${FULL_VERSION_TAG} ${LATEST_VERSION_TAG} --build-arg IVY_ENGINE_DOWNLOAD_URL=${ENGINE_URL} ${PUSHIT} ${buildContextDirectory}
+docker buildx build --no-cache --pull --tag ${IMAGE_TAG} ${FULL_VERSION_TAG} ${LATEST_VERSION_TAG} --provenance=true --build-arg IVY_ENGINE_DOWNLOAD_URL=${ENGINE_URL} ${PUSHIT} ${buildContextDirectory}


### PR DESCRIPTION
Because docker scout has no base image data:
https://docs.docker.com/scout/policy/#no-base-image-data