### PR TITLE
XIVY-16170 Set write permissions on the root folder `/ivy` for the group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-02-26
+
+### Fixed
+
+- Set write permissions on the root folder `/ivy` for the group. So that
+  you can run the container with arbitrary user (e.g. OpenShift).
+
 ## 2024-09-03
 
 ### Changed

--- a/axonivy-engine/12/Dockerfile
+++ b/axonivy-engine/12/Dockerfile
@@ -2,15 +2,18 @@ FROM docker.io/ubuntu:24.04 AS build
 
 ARG IVY_ENGINE_DOWNLOAD_URL
 
-ADD ${IVY_ENGINE_DOWNLOAD_URL} /tmp/ivy.zip
+ADD ${IVY_ENGINE_DOWNLOAD_URL} /ivy.zip
 RUN apt-get update && \
     apt-get install -y unzip && \
-    unzip /tmp/ivy.zip -d /tmp/ivy && \
-    mkdir /tmp/ivy/applications && \
-    mkdir /tmp/ivy/data && \
-    mkdir /tmp/ivy/logs && \
-    mkdir /tmp/ivy/configuration/applications && \
-    chmod -R g=u /tmp/ivy
+    unzip /ivy.zip -d /ivy && \
+    mkdir /ivy/applications && \
+    mkdir /ivy/data && \
+    mkdir /ivy/logs && \
+    mkdir /ivy/configuration/applications && \
+    # sets the permission of the group to the same as the user
+    # in OpenShift you need to run with any user but the user is
+    # part of the group
+    chmod -R g=u /ivy
 
 FROM docker.io/eclipse-temurin:21-jre-noble
 LABEL maintainer="Axon Ivy AG <info@axonivy.com>"
@@ -18,13 +21,12 @@ LABEL maintainer="Axon Ivy AG <info@axonivy.com>"
 RUN usermod -l ivy ubuntu && \
     groupmod -n ivy ubuntu
 
-ARG IVY_HOME=/ivy
-
-COPY --from=build --chown=1000:0 /tmp/ivy ${IVY_HOME}
+COPY --from=build --chown=1000:0 /ivy /ivy
+RUN chmod g+w /ivy
 
 VOLUME [ "/ivy/data", "/ivy/configuration", "/ivy/applications" ]
 
-WORKDIR ${IVY_HOME}
+WORKDIR /ivy
 USER 1000
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/ || exit 1


### PR DESCRIPTION
Seems like `COPY` does also copy the permissions of files, as
explained in the Dockerfile specs. But the copied root folder
won't be copied, it will be created by COPY itself.

No longer download in `/tmp` directory in staging layer, to
make the `Dockerfile` more readable.

Remove the `ARG=IVY_HOME`, not crucial in this `Dockerfile`.
