### PR TITLE
Install curl on the image

### DIFF
--- a/axonivy-engine/14/Dockerfile
+++ b/axonivy-engine/14/Dockerfile
@@ -22,7 +22,7 @@ RUN usermod -l ivy ubuntu && \
     groupmod -n ivy ubuntu
 
 RUN apt-get update && \
-    apt-get install -y wget && \
+    apt-get install -y curl wget && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=build --chown=1000:0 /ivy /ivy


### PR DESCRIPTION
- Because it was also on the old image
- We use it in docker-integration-tests
- May be later we should get rid of it